### PR TITLE
Ensure charge transaction for all payment methods

### DIFF
--- a/notification/src/handler/notification/notification.handler.js
+++ b/notification/src/handler/notification/notification.handler.js
@@ -329,7 +329,8 @@ async function calculateUpdateActionsForPayment(payment, notification, logger) {
       })
     }
 
-    if (transactionType == 'Authorization' && transactionState == 'Success' && !('CAPTURE' in notificationRequestItem.operations)) {
+    if (transactionType === 'Authorization' && transactionState === 'Success'
+        && !('CAPTURE' in notificationRequestItem.operations)) {
       updateActions.push(
         getAddTransactionUpdateAction({
           timestamp: convertDateToUTCFormat(eventDate, logger),

--- a/notification/src/handler/notification/notification.handler.js
+++ b/notification/src/handler/notification/notification.handler.js
@@ -328,6 +328,19 @@ async function calculateUpdateActionsForPayment(payment, notification, logger) {
         key: newPspReference,
       })
     }
+
+    if (transactionType == 'Authorization' && transactionState == 'Success' && !('CAPTURE' in notificationRequestItem.operations)) {
+      updateActions.push(
+        getAddTransactionUpdateAction({
+          timestamp: convertDateToUTCFormat(eventDate, logger),
+          type: 'Charge',
+          state: 'Success',
+          amount: notificationRequestItem.amount.value,
+          currency: notificationRequestItem.amount.currency,
+          interactionId: pspReference,
+        }),
+      )
+    }
   }
 
   const paymentMethodFromPayment = payment.paymentMethodInfo.method


### PR DESCRIPTION
If payment method doesn't support separate charge, Adyen won't send us notification. We create charge transaction so our system rely on its presence.