### PR TITLE
Feature/FRAZ-8421 - Revert splitting notification in Adyen integration module

### DIFF
--- a/notification/src/handler/notification/notification.handler.js
+++ b/notification/src/handler/notification/notification.handler.js
@@ -52,7 +52,7 @@ async function processNotification(
   let retryCount = 0
 
   const handleWebhook = async () => {
-    const payment = await getPaymentByMerchantReference(
+    let payment = await getPaymentByMerchantReference(
       merchantReference,
       originalReference || pspReference,
       ctpClient,
@@ -99,7 +99,6 @@ async function processNotification(
         // if pspReference or originalReference from webhook are the same as the payment key => standard update
         // if not => add a transaction with the message to the payment
         // so the merchant could see that the webhook wasn't correct
-
         await updatePaymentWithRepeater(
           payment,
           notification,
@@ -142,15 +141,16 @@ async function updatePaymentWithRepeater(
   let updateActions
   const repeater = async () => {
     updateActions = await calculateUpdateActionsForPayment(
-          currentPayment,
-          notification,
-          logger,
-        )
+      currentPayment,
+      notification,
+      logger,
+    )
     if (updateActions.length === 0) {
       return
     }
     logger.debug(
-      `Update payment with key ${currentPayment.key
+      `Update payment with key ${
+        currentPayment.key
       } with update actions [${JSON.stringify(updateActions)}]`,
     )
     try {
@@ -187,10 +187,10 @@ async function updatePaymentWithRepeater(
         throw new VError(
           err,
           `${retryMessage} Won't retry again` +
-          ` because of a reached limit ${maxRetry}` +
-          ` max retries. Failed actions: ${JSON.stringify(
-            updateActionsToLog,
-          )}`,
+            ` because of a reached limit ${maxRetry}` +
+            ` max retries. Failed actions: ${JSON.stringify(
+              updateActionsToLog,
+            )}`,
         )
       }
 
@@ -376,12 +376,12 @@ function getAddInterfaceInteractionUpdateAction(notification) {
   if (
     notificationToUse.NotificationRequestItem?.additionalData &&
     notificationToUse.NotificationRequestItem?.additionalData[
-    'recurring.recurringDetailReference'
+      'recurring.recurringDetailReference'
     ]
   ) {
     const recurringDetailReference =
       notificationToUse.NotificationRequestItem.additionalData[
-      'recurring.recurringDetailReference'
+        'recurring.recurringDetailReference'
       ]
 
     notificationToUse.NotificationRequestItem.recurringDetailReference =
@@ -391,7 +391,7 @@ function getAddInterfaceInteractionUpdateAction(notification) {
   if (
     notificationToUse.NotificationRequestItem?.additionalData &&
     notificationToUse.NotificationRequestItem?.additionalData[
-    'recurringProcessingModel'
+      'recurringProcessingModel'
     ]
   ) {
     const { recurringProcessingModel } =
@@ -404,12 +404,12 @@ function getAddInterfaceInteractionUpdateAction(notification) {
   if (
     notificationToUse.NotificationRequestItem?.additionalData &&
     notificationToUse.NotificationRequestItem?.additionalData[
-    'recurring.shopperReference'
+      'recurring.shopperReference'
     ]
   ) {
     const recurringShopperReference =
       notificationToUse.NotificationRequestItem.additionalData[
-      'recurring.shopperReference'
+        'recurring.shopperReference'
       ]
 
     notificationToUse.NotificationRequestItem.recurringShopperReference =

--- a/notification/src/utils/ctp.js
+++ b/notification/src/utils/ctp.js
@@ -130,13 +130,6 @@ async function setUpClient(config) {
       )
     },
 
-    fetchMatchingCartOrOrder(uri, paymentID) {
-      const paymentIDCondition = `paymentInfo(payments(id="${paymentID}"))`
-      return ctpClient.execute(
-        this.buildRequestOptions(uri.where(paymentIDCondition).build()),
-      )
-    },
-
     buildRequestOptions(uri, method = 'GET', body = undefined) {
       return {
         uri,


### PR DESCRIPTION
- reverted changes done a few months ago: _create new Payment Object in Commercetools after receiving authorisation notification with amount lower than planned amount_
- changed formatting in several places to have it exactly as it's in current master of original Adyen's repo

after this pull request, the only differences between our repo and Adyen's master will be:
![image](https://github.com/user-attachments/assets/62556f05-4cf9-457c-8864-c8b0dc838732)
